### PR TITLE
This PR fixes issues with `find_nearby_stations()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
   * Fixes bug where BOM and SILO metadata were not properly merged when using `find_nearby_stations()`
 
   * Fixes [bug](https://github.com/DPIRD-FSI/weatherOz/issues/36) where closed stations are included in the nearest stations when using `find_nearby_stations()` and `include_closed = FALSE` (default).
+  
+  * Fixes the messages when stations aren't found nearby. In certain cases the message indicated that a `station_code` was used when `latitude` and `longitude` had been provided and _vice versa_.
+  
+  * Fixes bug when there are no stations that meet the criteria set by the user and an error was emitted that "x" must be a data.table object. The function now simply errors if there are no stations from either API that meet the criteria.
 
 * `get_dpird_extremes()`
 

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -199,8 +199,8 @@ find_nearby_stations <- function(longitude = NULL,
   }
 
   out <- rbind(
-    if (exists("dpird_out")) dpird_out,
-    if (exists("silo_out")) silo_out)
+    if (!is.null("dpird_out")) dpird_out,
+    if (!is.null("silo_out")) silo_out)
 
   if (!exists("out", envir = sys.frame())) {
     stop(call. = FALSE,

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -199,10 +199,10 @@ find_nearby_stations <- function(longitude = NULL,
   }
 
   out <- rbind(
-    if (!is.null("dpird_out")) dpird_out,
-    if (!is.null("silo_out")) silo_out)
+    if (!is.null(dpird_out)) dpird_out,
+    if (!is.null(silo_out)) silo_out)
 
-  if (!exists("out", envir = sys.frame())) {
+  if (is.null(out)) {
     stop(call. = FALSE,
          "There are no stations found in the DPIRD or SILO networks ",
          "that match your criteria.")
@@ -275,7 +275,7 @@ find_nearby_stations <- function(longitude = NULL,
   if (nrow(dpird_out) == 0L) {
     if (!is.null(.latitude) && !is.null(.longitude)) {
       message(
-        "No DPIRD stations found around a radius of <",
+        "No DPIRD stations found within a radius of <",
         .distance_km,
         " km\n",
         " from coordinates ",
@@ -286,7 +286,7 @@ find_nearby_stations <- function(longitude = NULL,
       )
     } else {
       message(
-        "No DPIRD stations found around a radius of <",
+        "No DPIRD stations found within a radius of <",
         .distance_km,
         " km\n",
         " from station_code ",
@@ -361,19 +361,6 @@ find_nearby_stations <- function(longitude = NULL,
       out <-
         out[distance_km %in% out[(distance_km <= .distance_km)]$distance_km]
 
-      if (nrow(out) == 0L) {
-        message(
-          "No SILO stations found around a radius of < ",
-          .distance_km,
-          " km\n",
-          " from coordinates ",
-          .longitude,
-          " and ",
-          .latitude,
-          " (lon/lat).\n"
-        )
-        return(invisible(NULL))
-      }
     } else {
       out <-
         .query_silo_api(
@@ -382,19 +369,6 @@ find_nearby_stations <- function(longitude = NULL,
           .format = "near",
           .dataset = "PatchedPoint"
         )
-      if (nrow(out) == 0L) {
-        message(
-          "No SILO stations found around a radius of < ",
-          .distance_km,
-          " km\n for the given coordinates",
-          .longitude,
-          " and ",
-          .latitude,
-          "(lon/lat)."
-        )
-
-        return(invisible(NULL))
-      }
     }
 
     bom_stations <- .get_bom_metadata()
@@ -417,6 +391,31 @@ find_nearby_stations <- function(longitude = NULL,
     out[, source := NULL]
     out[, status := NULL]
     out[, wmo := NULL]
+
+    if (nrow(out) == 0L) {
+      if (!is.null(.longitude) && !is.null(.latitude)) {
+        message(
+          "No SILO stations found within a radius of <",
+          .distance_km,
+          " km\n",
+          " from coordinates ",
+          .longitude,
+          " and ",
+          .latitude,
+          " (lon/lat).\n"
+        )
+      } else {
+        message(
+          "No SILO stations found within a radius of <",
+          .distance_km,
+          " km\n",
+          " from `station_code` ",
+          .station_code,
+          ".\n"
+        )
+      }
+      return(invisible(NULL))
+    }
 
     data.table::setorder(x = out, cols = distance_km)
 

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -202,6 +202,10 @@ find_nearby_stations <- function(longitude = NULL,
     if (exists("dpird_out")) dpird_out,
     if (exists("silo_out")) silo_out)
 
+  if (nrow(out) == 0L) {
+    return(invisible(NULL))
+  }
+
   data.table::setorder(out, distance_km)
   return(out[])
 }

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -263,7 +263,8 @@ find_nearby_stations <- function(longitude = NULL,
                                 .limit = 1000)
 
   dpird_out <-
-    data.table::data.table(jsonlite::fromJSON(dpird_out[[1]]$parse("UTF8"))$collection)
+    data.table::data.table(
+      jsonlite::fromJSON(dpird_out[[1]]$parse("UTF8"))$collection)
 
   if (nrow(dpird_out) == 0L) {
     message(
@@ -347,9 +348,12 @@ find_nearby_stations <- function(longitude = NULL,
         message(
           "No SILO stations found around a radius of < ",
           .distance_km,
-          " km\n for the given `station_code`",
-          .station_code,
-          "."
+          " km\n",
+          " from coordinates ",
+          .longitude,
+          " and ",
+          .latitude,
+          " (lon/lat).\n"
         )
         return(invisible(NULL))
       }

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -198,10 +198,9 @@ find_nearby_stations <- function(longitude = NULL,
     )
   }
 
-  out <- rbind(if (exists("dpird_out"))
-    dpird_out,
-    if (exists("silo_out"))
-      silo_out)
+  out <- rbind(
+    if (exists("dpird_out")) dpird_out,
+    if (exists("silo_out")) silo_out)
 
   data.table::setorder(out, distance_km)
   return(out[])
@@ -267,16 +266,27 @@ find_nearby_stations <- function(longitude = NULL,
       jsonlite::fromJSON(dpird_out[[1]]$parse("UTF8"))$collection)
 
   if (nrow(dpird_out) == 0L) {
-    message(
-      "No DPIRD stations found around a radius of <",
-      .distance_km,
-      " km\n",
-      " from coordinates ",
-      .longitude,
-      " and ",
-      .latitude,
-      " (lon/lat).\n"
-    )
+    if (!is.null(.latitude) && !is.null(.longitude)) {
+      message(
+        "No DPIRD stations found around a radius of <",
+        .distance_km,
+        " km\n",
+        " from coordinates ",
+        .longitude,
+        " and ",
+        .latitude,
+        " (lon/lat).\n"
+      )
+    } else {
+      message(
+        "No DPIRD stations found around a radius of <",
+        .distance_km,
+        " km\n",
+        " from station_code ",
+        .station_code,
+        ".\n"
+      )
+    }
     return(invisible(NULL))
   }
 

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -202,9 +202,10 @@ find_nearby_stations <- function(longitude = NULL,
     if (exists("dpird_out")) dpird_out,
     if (exists("silo_out")) silo_out)
 
-  if (nrow(out) == 0L) {
+  if (!exists("out", envir = sys.frame())) {
     stop(call. = FALSE,
-         "There are no stations found that match your criteria.")
+         "There are no stations found in the DPIRD or SILO networks ",
+         "that match your criteria.")
     return(invisible(NULL))
   }
 

--- a/R/find_nearby_stations.R
+++ b/R/find_nearby_stations.R
@@ -203,6 +203,8 @@ find_nearby_stations <- function(longitude = NULL,
     if (exists("silo_out")) silo_out)
 
   if (nrow(out) == 0L) {
+    stop(call. = FALSE,
+         "There are no stations found that match your criteria.")
     return(invisible(NULL))
   }
 


### PR DESCRIPTION
Mainly issues surrounding the handling of errors when there are no stations found. 

The messages emitted when checking the APIs now reflect the input, either `station_code` or `latitude` and `longitude` and when no stations are found in either API the function stops with an `error`.