### PR TITLE
Fixes instances where SILO lon/lat were char not numeric values

### DIFF
--- a/R/query_silo_api.R
+++ b/R/query_silo_api.R
@@ -197,14 +197,14 @@
     }
 
     response_data[, latitude :=
-                    trimws(
+                    as.numeric(trimws(
                       gsub("latitude=", "",
                            response_data$metadata[grep(
-                             "latitude", response_data$metadata)]))]
+                             "latitude", response_data$metadata)])))]
     response_data[, longitude :=
-                    trimws(gsub("longitude=", "",
+                    as.numeric(trimws(gsub("longitude=", "",
                                 response_data$metadata[grep(
-                                  "longitude", response_data$metadata)]))]
+                                  "longitude", response_data$metadata)])))]
     .check_silo_codes(response_data)
   }
 


### PR DESCRIPTION
When requesting patchedPoint data, lon lat values were being returned erroneously as character values, not numeric. This patch fixes this bug.